### PR TITLE
Add /Zc:preprocessor to MSVC compiler

### DIFF
--- a/tools/windows.py
+++ b/tools/windows.py
@@ -31,7 +31,7 @@ def generate(env):
         env.Tool("mslink")
 
         env.Append(CPPDEFINES=["TYPED_METHOD_BIND", "NOMINMAX"])
-        env.Append(CCFLAGS=["/EHsc", "/utf-8"])
+        env.Append(CCFLAGS=["/EHsc", "/utf-8", "/Zc:preprocessor"])
         env.Append(LINKFLAGS=["/WX"])
 
         if env["use_clang_cl"]:


### PR DESCRIPTION
Necessary to support __VA_OPT__ and standardized __VA_ARG__ support