### PR TITLE
Update based on Godot 4.1.3 godot-cpp's scons scripts

### DIFF
--- a/tools/linux.py
+++ b/tools/linux.py
@@ -1,4 +1,4 @@
-# Copied from https://github.com/godotengine/godot-cpp/blob/2bf983e6382f5236948f7740faf130a3568f9dd0/tools/linux.py
+# Copied from https://github.com/godotengine/godot-cpp/blob/df5b1a9a692b0d972f5ac3c853371594cdec420b/tools/linux.py
 from SCons.Variables import *
 from SCons.Tool import clang, clangxx
 
@@ -33,3 +33,5 @@ def generate(env):
     elif env["arch"] == "rv64":
         env.Append(CCFLAGS=["-march=rv64gc"])
         env.Append(LINKFLAGS=["-march=rv64gc"])
+
+    env.Append(CPPDEFINES=["LINUX_ENABLED", "UNIX_ENABLED"])

--- a/tools/macos.py
+++ b/tools/macos.py
@@ -1,32 +1,52 @@
-# Copied from https://github.com/godotengine/godot-cpp/blob/2bf983e6382f5236948f7740faf130a3568f9dd0/tools/macos.py
+# Copied from https://github.com/godotengine/godot-cpp/blob/df5b1a9a692b0d972f5ac3c853371594cdec420b/tools/macos.py
 import os
 import sys
-import macos_osxcross
+
+
+def has_osxcross():
+    return "OSXCROSS_ROOT" in os.environ
 
 
 def options(opts):
     opts.Add("macos_deployment_target", "macOS deployment target", "default")
     opts.Add("macos_sdk_path", "macOS SDK path", "")
-    macos_osxcross.options(opts)
+    if has_osxcross():
+        opts.Add("osxcross_sdk", "OSXCross SDK version", "darwin16")
 
 
 def exists(env):
-    return sys.platform == "darwin" or macos_osxcross.exists(env)
+    return sys.platform == "darwin" or has_osxcross()
 
 
 def generate(env):
     if env["arch"] not in ("universal", "arm64", "x86_64"):
         print("Only universal, arm64, and x86_64 are supported on macOS. Exiting.")
-        Exit()
+        env.Exit(1)
 
     if sys.platform == "darwin":
         # Use clang on macOS by default
         env["CXX"] = "clang++"
         env["CC"] = "clang"
     else:
-        # Use osxcross
-        macos_osxcross.generate(env)
+        # OSXCross
+        root = os.environ.get("OSXCROSS_ROOT", "")
+        if env["arch"] == "arm64":
+            basecmd = root + "/target/bin/arm64-apple-" + env["osxcross_sdk"] + "-"
+        else:
+            basecmd = root + "/target/bin/x86_64-apple-" + env["osxcross_sdk"] + "-"
 
+        env["CC"] = basecmd + "clang"
+        env["CXX"] = basecmd + "clang++"
+        env["AR"] = basecmd + "ar"
+        env["RANLIB"] = basecmd + "ranlib"
+        env["AS"] = basecmd + "as"
+
+        binpath = os.path.join(root, "target", "bin")
+        if binpath not in env["ENV"]["PATH"]:
+            # Add OSXCROSS bin folder to PATH (required for linking).
+            env.PrependENVPath("PATH", binpath)
+
+    # Common flags
     if env["arch"] == "universal":
         env.Append(LINKFLAGS=["-arch", "x86_64", "-arch", "arm64"])
         env.Append(CCFLAGS=["-arch", "x86_64", "-arch", "arm64"])
@@ -49,3 +69,5 @@ def generate(env):
             "-Wl,-undefined,dynamic_lookup",
         ]
     )
+
+    env.Append(CPPDEFINES=["MACOS_ENABLED", "UNIX_ENABLED"])

--- a/tools/targets.py
+++ b/tools/targets.py
@@ -1,9 +1,13 @@
-# Copied from https://github.com/godotengine/godot-cpp/blob/edf02f83194b58408ca241459c986e32c52fd9c7/tools/targets.py
+# Copied from https://github.com/godotengine/godot-cpp/blob/df5b1a9a692b0d972f5ac3c853371594cdec420b/tools/targets.py
 import os
+import subprocess
 import sys
 from SCons.Script import ARGUMENTS
 from SCons.Variables import *
 from SCons.Variables.BoolVariable import _text2bool
+
+
+# Helper methods
 
 
 def get_cmdline_bool(option, default):
@@ -15,6 +19,24 @@ def get_cmdline_bool(option, default):
         return _text2bool(cmdline_val)
     else:
         return default
+
+
+def using_clang(env):
+    return "clang" in os.path.basename(env["CC"])
+
+
+def is_vanilla_clang(env):
+    if not using_clang(env):
+        return False
+    try:
+        version = subprocess.check_output([env.subst(env["CXX"]), "--version"]).strip().decode("utf-8")
+    except (subprocess.CalledProcessError, OSError):
+        print("Couldn't parse CXX environment variable to infer compiler version.")
+        return False
+    return not version.startswith("Apple")
+
+
+# Main tool definition
 
 
 def options(opts):
@@ -35,19 +57,21 @@ def exists(env):
 
 
 def generate(env):
+    # Configuration of build targets:
+    # - Editor or template
+    # - Debug features (DEBUG_ENABLED code)
+    # - Dev only code (DEV_ENABLED code)
+    # - Optimization level
+    # - Debug symbols for crash traces / debuggers
+
+    # Keep this configuration in sync with SConstruct in upstream Godot.
+
+    env.editor_build = env["target"] == "editor"
     env.dev_build = env["dev_build"]
     env.debug_features = env["target"] in ["editor", "template_debug"]
-    env.editor_build = env["target"] == "editor"
-
-    if env.editor_build:
-        env.AppendUnique(CPPDEFINES=["TOOLS_ENABLED"])
-
-    if env.debug_features:
-        env.AppendUnique(CPPDEFINES=["DEBUG_ENABLED", "DEBUG_METHODS_ENABLED"])
 
     if env.dev_build:
         opt_level = "none"
-        env.AppendUnique(CPPDEFINES=["DEV_ENABLED"])
     elif env.debug_features:
         opt_level = "speed_trace"
     else:  # Release
@@ -56,29 +80,57 @@ def generate(env):
     env["optimize"] = ARGUMENTS.get("optimize", opt_level)
     env["debug_symbols"] = get_cmdline_bool("debug_symbols", env.dev_build)
 
+    if env.editor_build:
+        env.Append(CPPDEFINES=["TOOLS_ENABLED"])
+
+    if env.debug_features:
+        # DEBUG_ENABLED enables debugging *features* and debug-only code, which is intended
+        # to give *users* extra debugging information for their game development.
+        env.Append(CPPDEFINES=["DEBUG_ENABLED"])
+        # In upstream Godot this is added in typedefs.h when DEBUG_ENABLED is set.
+        env.Append(CPPDEFINES=["DEBUG_METHODS_ENABLED"])
+
+    if env.dev_build:
+        # DEV_ENABLED enables *engine developer* code which should only be compiled for those
+        # working on the engine itself.
+        env.Append(CPPDEFINES=["DEV_ENABLED"])
+    else:
+        # Disable assert() for production targets (only used in thirdparty code).
+        env.Append(CPPDEFINES=["NDEBUG"])
+
+    # Set optimize and debug_symbols flags.
+    # "custom" means do nothing and let users set their own optimization flags.
     if env.get("is_msvc", False):
         if env["debug_symbols"]:
             env.Append(CCFLAGS=["/Zi", "/FS"])
             env.Append(LINKFLAGS=["/DEBUG:FULL"])
 
-        if env["optimize"] == "speed" or env["optimize"] == "speed_trace":
+        if env["optimize"] == "speed":
             env.Append(CCFLAGS=["/O2"])
             env.Append(LINKFLAGS=["/OPT:REF"])
+        elif env["optimize"] == "speed_trace":
+            env.Append(CCFLAGS=["/O2"])
+            env.Append(LINKFLAGS=["/OPT:REF", "/OPT:NOICF"])
         elif env["optimize"] == "size":
             env.Append(CCFLAGS=["/O1"])
             env.Append(LINKFLAGS=["/OPT:REF"])
-
-        if env["optimize"] == "debug" or env["optimize"] == "none":
-            env.Append(CCFLAGS=["/MDd", "/Od"])
-        else:
-            env.Append(CCFLAGS=["/MD"])
-
+        elif env["optimize"] == "debug" or env["optimize"] == "none":
+            env.Append(CCFLAGS=["/Od"])
     else:
         if env["debug_symbols"]:
+            # Adding dwarf-4 explicitly makes stacktraces work with clang builds,
+            # otherwise addr2line doesn't understand them.
+            env.Append(CCFLAGS=["-gdwarf-4"])
             if env.dev_build:
                 env.Append(CCFLAGS=["-g3"])
             else:
                 env.Append(CCFLAGS=["-g2"])
+        else:
+            if using_clang(env) and not is_vanilla_clang(env):
+                # Apple Clang, its linker doesn't like -s.
+                env.Append(LINKFLAGS=["-Wl,-S", "-Wl,-x", "-Wl,-dead_strip"])
+            else:
+                env.Append(LINKFLAGS=["-s"])
 
         if env["optimize"] == "speed":
             env.Append(CCFLAGS=["-O3"])


### PR DESCRIPTION
Can now run `scons compiledb=yes` instead of `scons compiledb=yes compiledb`