### PR TITLE
Implement scripts overhaul

### DIFF
--- a/tools/common_compiler_flags.py
+++ b/tools/common_compiler_flags.py
@@ -1,0 +1,127 @@
+# Based on https://github.com/godotengine/godot-cpp/blob/98ea2f60bb3846d6ae410d8936137d1b099cd50b/tools/common_compiler_flags.py
+import os
+import subprocess
+
+
+def using_clang(env):
+    return "clang" in os.path.basename(env["CC"])
+
+
+def is_vanilla_clang(env):
+    if not using_clang(env):
+        return False
+    try:
+        version = subprocess.check_output([env.subst(env["CXX"]), "--version"]).strip().decode("utf-8")
+    except (subprocess.CalledProcessError, OSError):
+        print("Couldn't parse CXX environment variable to infer compiler version.")
+        return False
+    return not version.startswith("Apple")
+
+
+def exists(env):
+    return True
+
+
+def generate(env):
+    assert env["lto"] in ["thin", "full", "none"], "Unrecognized lto: {}".format(env["lto"])
+    if env["lto"] != "none":
+        print("Using LTO: " + env["lto"])
+
+    # Require C++20
+    if env.get("is_msvc", False):
+        env.Append(CXXFLAGS=["/std:c++20"])
+    else:
+        env.Append(CXXFLAGS=["-std=c++20"])
+
+    if env["precision"] == "double":
+        env.Append(CPPDEFINES=["REAL_T_IS_DOUBLE"])
+
+    # Disable exception handling. Godot doesn't use exceptions anywhere, and this
+    # saves around 20% of binary size and very significant build time.
+    if env["disable_exceptions"]:
+        if env.get("is_msvc", False):
+            env.Append(CPPDEFINES=[("_HAS_EXCEPTIONS", 0)])
+        else:
+            env.Append(CXXFLAGS=["-fno-exceptions"])
+    elif env.get("is_msvc", False):
+        env.Append(CXXFLAGS=["/EHsc"])
+
+    if not env.get("is_msvc", False):
+        if env["symbols_visibility"] == "visible":
+            env.Append(CCFLAGS=["-fvisibility=default"])
+            env.Append(LINKFLAGS=["-fvisibility=default"])
+        elif env["symbols_visibility"] == "hidden":
+            env.Append(CCFLAGS=["-fvisibility=hidden"])
+            env.Append(LINKFLAGS=["-fvisibility=hidden"])
+
+    # Set optimize and debug_symbols flags.
+    # "custom" means do nothing and let users set their own optimization flags.
+    if env.get("is_msvc", False):
+        if env["debug_symbols"]:
+            env.Append(CCFLAGS=["/Zi", "/FS"])
+            env.Append(LINKFLAGS=["/DEBUG:FULL"])
+
+        if env["optimize"] == "speed":
+            env.Append(CCFLAGS=["/O2"])
+            env.Append(LINKFLAGS=["/OPT:REF"])
+        elif env["optimize"] == "speed_trace":
+            env.Append(CCFLAGS=["/O2"])
+            env.Append(LINKFLAGS=["/OPT:REF", "/OPT:NOICF"])
+        elif env["optimize"] == "size":
+            env.Append(CCFLAGS=["/O1"])
+            env.Append(LINKFLAGS=["/OPT:REF"])
+        elif env["optimize"] == "debug" or env["optimize"] == "none":
+            env.Append(CCFLAGS=["/Od"])
+
+        if env["lto"] == "thin":
+            if not env["use_llvm"]:
+                print("ThinLTO is only compatible with LLVM, use `use_llvm=yes` or `lto=full`.")
+                env.Exit(255)
+
+            env.Append(CCFLAGS=["-flto=thin"])
+            env.Append(LINKFLAGS=["-flto=thin"])
+        elif env["lto"] == "full":
+            if env["use_llvm"]:
+                env.Append(CCFLAGS=["-flto"])
+                env.Append(LINKFLAGS=["-flto"])
+            else:
+                env.AppendUnique(CCFLAGS=["/GL"])
+                env.AppendUnique(ARFLAGS=["/LTCG"])
+                env.AppendUnique(LINKFLAGS=["/LTCG"])
+    else:
+        if env["debug_symbols"]:
+            # Adding dwarf-4 explicitly makes stacktraces work with clang builds,
+            # otherwise addr2line doesn't understand them.
+            env.Append(CCFLAGS=["-gdwarf-4"])
+            if env.dev_build:
+                env.Append(CCFLAGS=["-g3"])
+            else:
+                env.Append(CCFLAGS=["-g2"])
+        else:
+            if using_clang(env) and not is_vanilla_clang(env) and not env["use_mingw"]:
+                # Apple Clang, its linker doesn't like -s.
+                env.Append(LINKFLAGS=["-Wl,-S", "-Wl,-x", "-Wl,-dead_strip"])
+            else:
+                env.Append(LINKFLAGS=["-s"])
+
+        if env["optimize"] == "speed":
+            env.Append(CCFLAGS=["-O3"])
+        # `-O2` is friendlier to debuggers than `-O3`, leading to better crash backtraces.
+        elif env["optimize"] == "speed_trace":
+            env.Append(CCFLAGS=["-O2"])
+        elif env["optimize"] == "size":
+            env.Append(CCFLAGS=["-Os"])
+        elif env["optimize"] == "debug":
+            env.Append(CCFLAGS=["-Og"])
+        elif env["optimize"] == "none":
+            env.Append(CCFLAGS=["-O0"])
+
+        if env["lto"] == "thin":
+            if (env["platform"] == "windows" or env["platform"] == "linux") and not env["use_llvm"]:
+                print("ThinLTO is only compatible with LLVM, use `use_llvm=yes` or `lto=full`.")
+                env.Exit(255)
+            env.Append(CCFLAGS=["-flto=thin"])
+            env.Append(LINKFLAGS=["-flto=thin"])
+        elif env["lto"] == "full":
+            env.Append(CCFLAGS=["-flto"])
+            env.Append(LINKFLAGS=["-flto"])

--- a/tools/linux.py
+++ b/tools/linux.py
@@ -1,4 +1,5 @@
-# Copied from https://github.com/godotengine/godot-cpp/blob/df5b1a9a692b0d972f5ac3c853371594cdec420b/tools/linux.py
+# Based on https://github.com/godotengine/godot-cpp/blob/98ea2f60bb3846d6ae410d8936137d1b099cd50b/tools/linux.py
+import common_compiler_flags
 from SCons.Variables import BoolVariable
 from SCons.Tool import clang, clangxx
 
@@ -20,6 +21,9 @@ def generate(env):
     if env["use_llvm"]:
         clang.generate(env)
         clangxx.generate(env)
+    elif env.use_hot_reload:
+        # Required for hot reload support.
+        env.Append(CXXFLAGS=["-fno-gnu-unique"])
 
     env.Append(CCFLAGS=["-fPIC", "-Wwrite-strings"])
     env.Append(LINKFLAGS=["-Wl,-R,'$$ORIGIN'"])
@@ -78,3 +82,8 @@ def generate(env):
             env.Append(LINKFLAGS=["-fsanitize=memory"])
 
     env.Append(CPPDEFINES=["LINUX_ENABLED", "UNIX_ENABLED"])
+
+    if env["lto"] == "auto":
+        env["lto"] = "full"
+
+    common_compiler_flags.generate(env)

--- a/tools/macos.py
+++ b/tools/macos.py
@@ -1,6 +1,8 @@
-# Copied from https://github.com/godotengine/godot-cpp/blob/df5b1a9a692b0d972f5ac3c853371594cdec420b/tools/macos.py
+# Based on https://github.com/godotengine/godot-cpp/blob/98ea2f60bb3846d6ae410d8936137d1b099cd50b/tools/macos.py
 import os
 import sys
+
+import common_compiler_flags
 from SCons.Variables import BoolVariable
 
 
@@ -96,3 +98,8 @@ def generate(env):
             env.Append(LINKFLAGS=["-fsanitize=thread"])
 
     env.Append(CPPDEFINES=["MACOS_ENABLED", "UNIX_ENABLED"])
+
+    if env["lto"] == "auto":
+        env["lto"] = "none"
+
+    common_compiler_flags.generate(env)

--- a/tools/windows.py
+++ b/tools/windows.py
@@ -1,17 +1,87 @@
-# Copied from https://github.com/godotengine/godot-cpp/blob/df5b1a9a692b0d972f5ac3c853371594cdec420b/tools/windows.py
+# Based on https://github.com/godotengine/godot-cpp/blob/98ea2f60bb3846d6ae410d8936137d1b099cd50b/tools/windows.py
+import os
 import sys
 
+import common_compiler_flags
 import my_spawn
-
-from SCons.Tool import msvc, mingw
+from SCons.Tool import mingw, msvc
 from SCons.Variables import BoolVariable
 
 
+def silence_msvc(env):
+    import os
+    import re
+    import tempfile
+
+    # Ensure we have a location to write captured output to, in case of false positives.
+    capture_path = os.path.join(os.path.dirname(__file__), "..", "msvc_capture.log")
+    with open(capture_path, "wt", encoding="utf-8"):
+        pass
+
+    old_spawn = env["SPAWN"]
+    re_redirect_stream = re.compile(r"^[12]?>")
+    re_cl_capture = re.compile(r"^.+\.(c|cc|cpp|cxx|c[+]{2})$", re.IGNORECASE)
+    re_link_capture = re.compile(r'\s{3}\S.+\s(?:"[^"]+.lib"|\S+.lib)\s.+\s(?:"[^"]+.exp"|\S+.exp)')
+
+    def spawn_capture(sh, escape, cmd, args, env):
+        # We only care about cl/link, process everything else as normal.
+        if args[0] not in ["cl", "link"]:
+            return old_spawn(sh, escape, cmd, args, env)
+
+        # Process as normal if the user is manually rerouting output.
+        for arg in args:
+            if re_redirect_stream.match(arg):
+                return old_spawn(sh, escape, cmd, args, env)
+
+        tmp_stdout, tmp_stdout_name = tempfile.mkstemp()
+        os.close(tmp_stdout)
+        args.append(f">{tmp_stdout_name}")
+        ret = old_spawn(sh, escape, cmd, args, env)
+
+        try:
+            with open(tmp_stdout_name, "r", encoding=sys.stdout.encoding, errors="replace") as tmp_stdout:
+                lines = tmp_stdout.read().splitlines()
+            os.remove(tmp_stdout_name)
+        except OSError:
+            pass
+
+        # Early process no lines (OSError)
+        if not lines:
+            return ret
+
+        is_cl = args[0] == "cl"
+        content = ""
+        caught = False
+        for line in lines:
+            # These conditions are far from all-encompassing, but are specialized
+            # for what can be reasonably expected to show up in the repository.
+            if not caught and (is_cl and re_cl_capture.match(line)) or (not is_cl and re_link_capture.match(line)):
+                caught = True
+                try:
+                    with open(capture_path, "a", encoding=sys.stdout.encoding) as log:
+                        log.write(line + "\n")
+                except OSError:
+                    print(f'WARNING: Failed to log captured line: "{line}".')
+                continue
+            content += line + "\n"
+        # Content remaining assumed to be an error/warning.
+        if content:
+            sys.stderr.write(content)
+
+        return ret
+
+    env["SPAWN"] = spawn_capture
+
+
 def options(opts):
+    mingw = os.getenv("MINGW_PREFIX", "")
+
     opts.Add(BoolVariable("use_mingw", "Use the MinGW compiler instead of MSVC - only effective on Windows", False))
-    opts.Add(BoolVariable("use_clang_cl", "Use the clang driver instead of MSVC - only effective on Windows", False))
     opts.Add(BoolVariable("use_static_cpp", "Link MinGW/MSVC C++ runtime libraries statically", False))
+    opts.Add(BoolVariable("silence_msvc", "Silence MSVC's cl/link stdout bloat, redirecting errors to stderr.", True))
     opts.Add(BoolVariable("debug_crt", "Compile with MSVC's debug CRT (/MDd)", False))
+    opts.Add(BoolVariable("use_llvm", "Use the LLVM compiler (MVSC or MinGW depending on the use_mingw flag)", False))
+    opts.Add("mingw_prefix", "MinGW prefix", mingw)
     opts.Add(BoolVariable("use_asan", "Use address sanitizer (ASAN)", False))
 
 
@@ -32,12 +102,22 @@ def generate(env):
     if not env["use_mingw"] and msvc_found:
         if env["arch"] == "x86_64":
             env["TARGET_ARCH"] = "amd64"
+        elif env["arch"] == "arm64":
+            env["TARGET_ARCH"] = "arm64"
+        elif env["arch"] == "arm32":
+            env["TARGET_ARCH"] = "arm"
         elif env["arch"] == "x86_32":
             env["TARGET_ARCH"] = "x86"
+
+        env["MSVC_SETUP_RUN"] = False  # Need to set this to re-run the tool
+        env["MSVS_VERSION"] = None
+        env["MSVC_VERSION"] = None
+
         env["is_msvc"] = True
 
         # MSVC, linker, and archiver.
         msvc.generate(env)
+        env.Tool("msvc")
         env.Tool("mslib")
         env.Tool("mslink")
 
@@ -45,7 +125,7 @@ def generate(env):
         env.Append(CCFLAGS=["/utf-8", "/Zc:preprocessor"])
         env.Append(LINKFLAGS=["/WX"])
 
-        if env["use_clang_cl"]:
+        if env["use_llvm"]:
             env["CC"] = "clang-cl"
             env["CXX"] = "clang-cl"
 
@@ -54,11 +134,14 @@ def generate(env):
             env.AppendUnique(CCFLAGS=["/MDd"])
         else:
             if env["use_static_cpp"]:
-                env.Append(CCFLAGS=["/MT"])
+                env.AppendUnique(CCFLAGS=["/MT"])
             else:
-                env.Append(CCFLAGS=["/MD"])
+                env.AppendUnique(CCFLAGS=["/MD"])
 
-    elif (sys.platform == "win32" or sys.platform == "msys") and mingw_found:
+        if env["silence_msvc"] and not env.GetOption("clean"):
+            silence_msvc(env)
+
+    elif (sys.platform == "win32" or sys.platform == "msys") and not env["mingw_prefix"]:
         env["use_mingw"] = True
         mingw.generate(env)
         # Don't want lib prefixes
@@ -81,15 +164,35 @@ def generate(env):
         # Long line hack. Use custom spawn, quick AR append (to avoid files with the same names to override each other).
         my_spawn.configure(env)
 
-    elif mingw_found:
+    else:
         env["use_mingw"] = True
         # Cross-compilation using MinGW
-        prefix = "i686" if env["arch"] == "x86_32" else env["arch"]
-        env["CXX"] = prefix + "-w64-mingw32-g++"
-        env["CC"] = prefix + "-w64-mingw32-gcc"
-        env["AR"] = prefix + "-w64-mingw32-ar"
-        env["RANLIB"] = prefix + "-w64-mingw32-ranlib"
-        env["LINK"] = prefix + "-w64-mingw32-g++"
+        prefix = ""
+        if env["mingw_prefix"]:
+            prefix = env["mingw_prefix"] + "/bin/"
+
+        if env["arch"] == "x86_64":
+            prefix += "x86_64"
+        elif env["arch"] == "arm64":
+            prefix += "aarch64"
+        elif env["arch"] == "arm32":
+            prefix += "armv7"
+        elif env["arch"] == "x86_32":
+            prefix += "i686"
+
+        if env["use_llvm"]:
+            env["CXX"] = prefix + "-w64-mingw32-clang++"
+            env["CC"] = prefix + "-w64-mingw32-clang"
+            env["AR"] = prefix + "-w64-mingw32-llvm-ar"
+            env["RANLIB"] = prefix + "-w64-mingw32-ranlib"
+            env["LINK"] = prefix + "-w64-mingw32-clang"
+        else:
+            env["CXX"] = prefix + "-w64-mingw32-g++"
+            env["CC"] = prefix + "-w64-mingw32-gcc"
+            env["AR"] = prefix + "-w64-mingw32-gcc-ar"
+            env["RANLIB"] = prefix + "-w64-mingw32-ranlib"
+            env["LINK"] = prefix + "-w64-mingw32-g++"
+
         # Want dll suffix
         env["SHLIBSUFFIX"] = ".dll"
 
@@ -103,8 +206,13 @@ def generate(env):
                     "-static-libstdc++",
                 ]
             )
+        if env["use_llvm"]:
+            env.Append(LINKFLAGS=["-lstdc++"])
 
-    else:
+        if sys.platform == "win32" or sys.platform == "msys":
+            my_spawn.configure(env)
+
+    if env["use_mingw"] and not mingw_found:
         print("'use_mingw' set but Mingw is not installed, please install Mingw first.")
         env.Exit(1)
 
@@ -114,3 +222,12 @@ def generate(env):
         env.Append(CCFLAGS=["/fsanitize=address"])
 
     env.Append(CPPDEFINES=["WINDOWS_ENABLED"])
+
+    if env["lto"] == "auto":
+        if env.get("is_msvc", False):
+            # No LTO by default for MSVC, doesn't help.
+            env["lto"] = "none"
+        else:  # Release
+            env["lto"] = "full"
+
+    common_compiler_flags.generate(env)


### PR DESCRIPTION
Add link-time optimization support
Add symbol visibility control for optimization
Add hot reload support
Add silence msvc for msvc link bloat
Replace use_clang_cl with use_llvm
Move common compiler flags to common_compiler_flags.py
Rename javascript platform to web (still ignored)

Using `lto=full`, the implicit `-fvisibility=hidden`,  `optimize=speed`, and `target=template_release` on gcc for linux x86_64, OpenVicProject/OpenVic-Simulation@7c89becb9d64f56920bef150842a125e84107798 reports 10 day ticks takes 440995265ns, or 0.44 seconds on my local machine. Extrapolated to complete 100 years it would be estimated to take less than 27 minutes with said speed.