### PR TITLE
Revert "Merge pull request #17 from OpenVicProject/fix-missing-lto"

### DIFF
--- a/build/common_compiler_flags.py
+++ b/build/common_compiler_flags.py
@@ -23,11 +23,7 @@ def exists(env):
 
 
 def generate(env):
-    if "lto" in env:
-        assert env["lto"] in ["thin", "full", "none"], "Unrecognized lto: {}".format(env["lto"])
-    else:
-        env["lto"] = "none"
-
+    assert env["lto"] in ["thin", "full", "none"], "Unrecognized lto: {}".format(env["lto"])
     if env["lto"] != "none":
         print("Using LTO: " + env["lto"])
 


### PR DESCRIPTION
- Reverts #17

This reverts commit 5abbb9cc44c81319fd9d10bcf16cf47fe1126027, reversing changes made to 7c595f64caea387ca8b4d89a000c5c2c27cf714d.

This was an erroneously bugged solved poorly by pollution of the python global modules which was solved by #18