### PR TITLE
Change TOOLPATH to use abspath

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -48,7 +48,7 @@ except:
     env = Environment(tools=["default"], PLATFORM="")
     old_env = env
 
-env.TOOLPATH = [env.Dir("../").rel_path(env.Dir("tools"))]
+env.TOOLPATH = [env.Dir("tools").abspath]
 env.is_standalone = is_standalone
 env.show_progress = show_progress
 


### PR DESCRIPTION
This should correct the behavior of scripts seemingly using the top-level's TOOLPATH.